### PR TITLE
Add multi-package publish workflows for NuGet automation

### DIFF
--- a/.github/workflows/pack-and-publish-all.yml
+++ b/.github/workflows/pack-and-publish-all.yml
@@ -1,0 +1,117 @@
+name: Pack & Publish
+
+on:
+  workflow_call:
+    inputs:
+      TriggerBranch:
+        description: 'Branch prefix that triggered the build (e.g. release/)'
+        required: true
+        type: string
+      ProjectName:
+        description: 'Path to the .csproj file (e.g. LCTWorks.Core/LCTWorks.Core.csproj)'
+        required: true
+        type: string
+      UpdatePackages:
+        description: 'Comma-separated internal package names to update to the extracted version'
+        required: false
+        type: string
+        default: ''
+      Runner:
+        description: 'GitHub-hosted runner label'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+      UseMSBuild:
+        description: 'Use MSBuild instead of dotnet CLI for build and pack'
+        required: false
+        type: boolean
+        default: false
+      Environment:
+        description: 'GitHub environment for deployment protection rules (empty = no approval)'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      version:
+        description: 'Extracted package version'
+        value: ${{ jobs.build-publish.outputs.version }}
+    secrets:
+      NUGET_API_KEY:
+        required: true
+
+env:
+  DOTNET_VERSION: "9.0.x"
+
+jobs:
+  build-publish:
+    runs-on: ${{ inputs.Runner }}
+    environment: ${{ inputs.Environment || null }}
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup MSBuild
+        if: ${{ inputs.UseMSBuild }}
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Extract version from branch name
+        id: version
+        shell: bash
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          VERSION="${BRANCH#${{ inputs.TriggerBranch }}}"
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update internal package references
+        if: ${{ inputs.UpdatePackages != '' }}
+        shell: pwsh
+        run: |
+          $packages = "${{ inputs.UpdatePackages }}".Split(',', [System.StringSplitOptions]::RemoveEmptyEntries)
+          $version = "${{ steps.version.outputs.value }}"
+          $csproj = "${{ inputs.ProjectName }}"
+          $content = Get-Content $csproj -Raw
+          foreach ($pkg in $packages) {
+            $pkg = $pkg.Trim()
+            $pattern = '(<PackageReference\s+Include="' + [regex]::Escape($pkg) + '"\s+Version=")[^"]*"'
+            $replacement = '${1}' + $version + '"'
+            $content = [regex]::Replace($content, $pattern, $replacement)
+          }
+          Set-Content $csproj $content -NoNewline
+          Write-Host "Updated package references in ${csproj}:"
+          Get-Content $csproj
+
+      - name: Restore dependencies
+        run: dotnet restore ${{ inputs.ProjectName }}
+
+      - name: Build
+        if: ${{ !inputs.UseMSBuild }}
+        run: dotnet build ${{ inputs.ProjectName }} -c Release --no-restore
+
+      - name: Build (MSBuild)
+        if: ${{ inputs.UseMSBuild }}
+        run: msbuild ${{ inputs.ProjectName }} -p:Configuration=Release -p:Platform=AnyCPU -restore:false
+
+      - name: Pack NuGet package
+        if: ${{ !inputs.UseMSBuild }}
+        run: dotnet pack ${{ inputs.ProjectName }} -c Release -p:Version=${{ steps.version.outputs.value }} --no-build --output ./nupkg
+
+      - name: Pack NuGet package (MSBuild)
+        if: ${{ inputs.UseMSBuild }}
+        shell: pwsh
+        run: |
+          $nupkgDir = Join-Path $env:GITHUB_WORKSPACE "nupkg"
+          msbuild ${{ inputs.ProjectName }} -t:Pack -p:Configuration=Release -p:Platform=AnyCPU -p:Version=${{ steps.version.outputs.value }} "-p:PackageOutputPath=$nupkgDir" -restore:false
+
+      - name: Push to NuGet
+        shell: bash
+        run: dotnet nuget push "./nupkg/*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+ 

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -1,0 +1,81 @@
+name: Publish All NuGet Packages
+
+on:
+  push:
+    branches:
+      - 'release/all/*'
+
+jobs:
+  # ──────────────────────────────────────────────
+  # Tier 0 — LCTWorks.Core (no internal deps)
+  # ──────────────────────────────────────────────
+  publish-core:
+    uses: ./.github/workflows/pack-and-publish-all.yml
+    with:
+      TriggerBranch: "release/"
+      ProjectName: "LCTWorks.Core/LCTWorks.Core.csproj"
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  # ──────────────────────────────────────────────
+  # Tier 2a — LCTWorks.Telemetry (depends on Core)
+  # Pauses for approval via the release-telemetry environment
+  # ──────────────────────────────────────────────
+  publish-telemetry:
+    needs: publish-core
+    uses: ./.github/workflows/pack-and-publish-all.yml
+    with:
+      TriggerBranch: "release/all/"
+      ProjectName: "LCTWorks.Telemetry/LCTWorks.Telemetry.csproj"
+      UpdatePackages: "LCTWorks.Core"
+      Environment: "release-telemetry"
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  # ──────────────────────────────────────────────
+  # Tier 2b — LCTWorks.Web (depends on Core)
+  # Pauses for approval via the release-web environment
+  # ──────────────────────────────────────────────
+  publish-web:
+    needs: publish-core
+    uses: ./.github/workflows/pack-and-publish-all.yml
+    with:
+      TriggerBranch: "release/all/"
+      ProjectName: "LCTWorks.Web/LCTWorks.Web.csproj"
+      UpdatePackages: "LCTWorks.Core"
+      Environment: "release-web"
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  # ──────────────────────────────────────────────
+  # Tier 3 — LCTWorks.WinUI (depends on Core + Telemetry)
+  # Pauses for approval via the release-winui environment
+  # ──────────────────────────────────────────────
+  publish-winui:
+    needs: [publish-telemetry, publish-web]
+    uses: ./.github/workflows/pack-and-publish-all.yml
+    with:
+      TriggerBranch: "release/all/"
+      ProjectName: "LCTWorks.WinUI/LCTWorks.WinUI.csproj"
+      UpdatePackages: "LCTWorks.Core,LCTWorks.Telemetry"
+      Runner: "windows-latest"
+      UseMSBuild: true
+      Environment: "release-winui"
+    secrets:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  tag:
+    needs: publish-winui
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v4
+
+     - name: Create and push tag
+       run: |
+         TAG="${{ needs.publish-winui.outputs.version }}"
+         git tag "$TAG"
+         git push origin "$TAG"

--- a/LCTWorks-Toolkit.slnx
+++ b/LCTWorks-Toolkit.slnx
@@ -4,7 +4,9 @@
     <File Path=".github/workflows/build-Telemetry.yml" />
     <File Path=".github/workflows/build-web.yml" />
     <File Path=".github/workflows/build-winui.yml" />
+    <File Path=".github/workflows/pack-and-publish-all.yml" />
     <File Path=".github/workflows/package-publish.yml" />
+    <File Path=".github/workflows/publish-all.yml" />
   </Folder>
   <Project Path="LCTWorks.Core/LCTWorks.Core.csproj" />
   <Project Path="LCTWorks.Telemetry/LCTWorks.Telemetry.csproj" />


### PR DESCRIPTION
Introduce reusable GitHub Actions workflows to automate building, packing, and publishing all NuGet packages in dependency order. Includes support for internal dependency version updates, environment-based approvals, and automatic tagging after release. Workflows are registered in the solution for streamlined multi-package releases.