### PR TITLE
Update publish-core TriggerBranch to 'release/all/'

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -12,7 +12,7 @@ jobs:
   publish-core:
     uses: ./.github/workflows/pack-and-publish-all.yml
     with:
-      TriggerBranch: "release/"
+      TriggerBranch: "release/all/"
       ProjectName: "LCTWorks.Core/LCTWorks.Core.csproj"
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
Changed TriggerBranch in publish-all.yml for publish-core job to trigger only on 'release/all/' branch instead of any branch starting with 'release/'. This narrows workflow activation.